### PR TITLE
feat: Add configurable endpoint paths for API adapters

### DIFF
--- a/src/ExchangeRateComparator.Application/Services/ExchangeRateComparatorService.cs
+++ b/src/ExchangeRateComparator.Application/Services/ExchangeRateComparatorService.cs
@@ -67,14 +67,15 @@ public class ExchangeRateComparatorService : IExchangeRateComparatorService
             throw new InvalidOperationException("All exchange rate providers failed. Please try again later.");
         }
 
-        // Select the best result (highest converted amount)
+        // Select the best result (highest converted amount, then fastest execution time as tiebreaker)
         var bestResult = successfulResults
             .OrderByDescending(r => r.ConvertedAmount)
+            .ThenBy(r => r.ExecutionTimeMs)
             .First();
 
         _logger.LogInformation(
-            "Best rate found: {Rate} from {Provider} with converted amount {ConvertedAmount}",
-            bestResult.Rate, bestResult.ProviderName, bestResult.ConvertedAmount);
+            "Best rate found: {Rate} from {Provider} with converted amount {ConvertedAmount} (execution time: {ExecutionTimeMs}ms)",
+            bestResult.Rate, bestResult.ProviderName, bestResult.ConvertedAmount, bestResult.ExecutionTimeMs);
 
         return new ExchangeResponse
         {

--- a/src/ExchangeRateComparator.Console/appsettings.json
+++ b/src/ExchangeRateComparator.Console/appsettings.json
@@ -9,16 +9,19 @@
   "ExchangeRateApis": {
     "Api1": {
       "BaseUrl": "http://localhost:5298/",
+      "EndpointPath": "/api/exchange",
       "TimeoutSeconds": 10,
       "Enabled": true
     },
     "Api2": {
       "BaseUrl": "http://localhost:5298/",
+      "EndpointPath": "/api/exchange",
       "TimeoutSeconds": 10,
       "Enabled": true
     },
     "Api3": {
       "BaseUrl": "http://localhost:5298/",
+      "EndpointPath": "/api/exchange",
       "TimeoutSeconds": 10,
       "Enabled": true
     }

--- a/src/ExchangeRateComparator.Infrastructure/Adapters/Api1JsonAdapter.cs
+++ b/src/ExchangeRateComparator.Infrastructure/Adapters/Api1JsonAdapter.cs
@@ -2,8 +2,10 @@ using System.Diagnostics;
 using System.Text.Json;
 using ExchangeRateComparator.Domain.Entities;
 using ExchangeRateComparator.Domain.Interfaces;
+using ExchangeRateComparator.Infrastructure.Configuration;
 using ExchangeRateComparator.Infrastructure.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace ExchangeRateComparator.Infrastructure.Adapters;
 
@@ -24,16 +26,22 @@ public class Api1JsonAdapter : IExchangeRateProvider
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<Api1JsonAdapter> _logger;
+    private readonly string _endpointPath;
 
     public string ProviderName => "API1-JSON";
 
-    public Api1JsonAdapter(HttpClient httpClient, ILogger<Api1JsonAdapter> logger)
+    public Api1JsonAdapter(
+        HttpClient httpClient, 
+        ILogger<Api1JsonAdapter> logger,
+        IOptions<ExchangeRateApiSettings> settings)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(settings);
 
         _httpClient = httpClient;
         _logger = logger;
+        _endpointPath = settings.Value.Api1.EndpointPath;
     }
 
     public async Task<ExchangeResult> GetExchangeRateAsync(ExchangeRequest request, CancellationToken cancellationToken = default)
@@ -54,9 +62,9 @@ public class Api1JsonAdapter : IExchangeRateProvider
             var json = JsonSerializer.Serialize(apiRequest);
             var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
 
-            _logger.LogDebug("Sending request to {Provider}", ProviderName);
+            _logger.LogDebug("Sending request to {Provider} at {EndpointPath}", ProviderName, _endpointPath);
 
-            var response = await _httpClient.PostAsync("/api/exchange", content, cancellationToken);
+            var response = await _httpClient.PostAsync(_endpointPath, content, cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/ExchangeRateComparator.Infrastructure/Adapters/Api2XmlAdapter.cs
+++ b/src/ExchangeRateComparator.Infrastructure/Adapters/Api2XmlAdapter.cs
@@ -3,8 +3,10 @@ using System.Text;
 using System.Xml.Serialization;
 using ExchangeRateComparator.Domain.Entities;
 using ExchangeRateComparator.Domain.Interfaces;
+using ExchangeRateComparator.Infrastructure.Configuration;
 using ExchangeRateComparator.Infrastructure.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace ExchangeRateComparator.Infrastructure.Adapters;
 
@@ -15,16 +17,22 @@ public class Api2XmlAdapter : IExchangeRateProvider
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<Api2XmlAdapter> _logger;
+    private readonly string _endpointPath;
 
     public string ProviderName => "API2-XML";
 
-    public Api2XmlAdapter(HttpClient httpClient, ILogger<Api2XmlAdapter> logger)
+    public Api2XmlAdapter(
+        HttpClient httpClient, 
+        ILogger<Api2XmlAdapter> logger,
+        IOptions<ExchangeRateApiSettings> settings)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(settings);
 
         _httpClient = httpClient;
         _logger = logger;
+        _endpointPath = settings.Value.Api2.EndpointPath;
     }
 
     public async Task<ExchangeResult> GetExchangeRateAsync(ExchangeRequest request, CancellationToken cancellationToken = default)
@@ -45,9 +53,9 @@ public class Api2XmlAdapter : IExchangeRateProvider
             var xml = SerializeToXml(apiRequest);
             var content = new StringContent(xml, Encoding.UTF8, "application/xml");
 
-            _logger.LogDebug("Sending request to {Provider}", ProviderName);
+            _logger.LogDebug("Sending request to {Provider} at {EndpointPath}", ProviderName, _endpointPath);
 
-            var response = await _httpClient.PostAsync("/api/exchange", content, cancellationToken);
+            var response = await _httpClient.PostAsync(_endpointPath, content, cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/ExchangeRateComparator.Infrastructure/Adapters/Api3JsonAdapter.cs
+++ b/src/ExchangeRateComparator.Infrastructure/Adapters/Api3JsonAdapter.cs
@@ -2,8 +2,10 @@ using System.Diagnostics;
 using System.Text.Json;
 using ExchangeRateComparator.Domain.Entities;
 using ExchangeRateComparator.Domain.Interfaces;
+using ExchangeRateComparator.Infrastructure.Configuration;
 using ExchangeRateComparator.Infrastructure.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace ExchangeRateComparator.Infrastructure.Adapters;
 
@@ -14,16 +16,22 @@ public class Api3JsonAdapter : IExchangeRateProvider
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<Api3JsonAdapter> _logger;
+    private readonly string _endpointPath;
 
     public string ProviderName => "API3-JSON";
 
-    public Api3JsonAdapter(HttpClient httpClient, ILogger<Api3JsonAdapter> logger)
+    public Api3JsonAdapter(
+        HttpClient httpClient, 
+        ILogger<Api3JsonAdapter> logger,
+        IOptions<ExchangeRateApiSettings> settings)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(settings);
 
         _httpClient = httpClient;
         _logger = logger;
+        _endpointPath = settings.Value.Api3.EndpointPath;
     }
 
     public async Task<ExchangeResult> GetExchangeRateAsync(ExchangeRequest request, CancellationToken cancellationToken = default)
@@ -47,9 +55,9 @@ public class Api3JsonAdapter : IExchangeRateProvider
             var json = JsonSerializer.Serialize(apiRequest);
             var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
 
-            _logger.LogDebug("Sending request to {Provider}", ProviderName);
+            _logger.LogDebug("Sending request to {Provider} at {EndpointPath}", ProviderName, _endpointPath);
 
-            var response = await _httpClient.PostAsync("/api/exchange", content, cancellationToken);
+            var response = await _httpClient.PostAsync(_endpointPath, content, cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/ExchangeRateComparator.Infrastructure/Configuration/ExchangeRateApiSettings.cs
+++ b/src/ExchangeRateComparator.Infrastructure/Configuration/ExchangeRateApiSettings.cs
@@ -38,6 +38,11 @@ public class ApiEndpointSettings
     public string BaseUrl { get; set; } = string.Empty;
 
     /// <summary>
+    /// Relative endpoint path for the exchange rate API
+    /// </summary>
+    public string EndpointPath { get; set; } = "/api/exchange";
+
+    /// <summary>
     /// Timeout in seconds for API requests
     /// </summary>
     public int TimeoutSeconds { get; set; } = 10;

--- a/tests/ExchangeRateComparator.Tests/Adapters/Api1JsonAdapterTests.cs
+++ b/tests/ExchangeRateComparator.Tests/Adapters/Api1JsonAdapterTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using ExchangeRateComparator.Domain.Entities;
 using ExchangeRateComparator.Infrastructure.Adapters;
+using ExchangeRateComparator.Infrastructure.Configuration;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using RichardSzalay.MockHttp;
 
@@ -19,6 +21,21 @@ public class Api1JsonAdapterTests
         _mockHttp = new MockHttpMessageHandler();
     }
 
+    private static IOptions<ExchangeRateApiSettings> CreateMockSettings(string endpointPath = "/api/exchange")
+    {
+        var settings = new ExchangeRateApiSettings
+        {
+            Api1 = new ApiEndpointSettings
+            {
+                BaseUrl = "http://localhost:5298/",
+                EndpointPath = endpointPath,
+                TimeoutSeconds = 10,
+                Enabled = true
+            }
+        };
+        return Options.Create(settings);
+    }
+
     [Fact]
     public async Task GetExchangeRateAsync_WhenApiReturnsSuccess_ShouldReturnSuccessResult()
     {
@@ -32,7 +49,7 @@ public class Api1JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api1.example.com/");
 
-        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -58,7 +75,7 @@ public class Api1JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api1.example.com/");
 
-        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -82,7 +99,7 @@ public class Api1JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api1.example.com/");
 
-        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -106,7 +123,7 @@ public class Api1JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api1.example.com/");
 
-        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -134,7 +151,7 @@ public class Api1JsonAdapterTests
         httpClient.BaseAddress = new Uri("https://api1.example.com/");
         httpClient.Timeout = TimeSpan.FromMilliseconds(100);
 
-        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -162,7 +179,7 @@ public class Api1JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api1.example.com/");
 
-        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Cancel immediately
         cts.Cancel();
@@ -193,7 +210,7 @@ public class Api1JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api1.example.com/");
 
-        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -209,7 +226,7 @@ public class Api1JsonAdapterTests
     {
         // Arrange
         var httpClient = _mockHttp.ToHttpClient();
-        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act & Assert
         adapter.ProviderName.Should().Be("API1-JSON");
@@ -219,7 +236,7 @@ public class Api1JsonAdapterTests
     public void Constructor_WhenHttpClientIsNull_ShouldThrowArgumentNullException()
     {
         // Act & Assert
-        var act = () => new Api1JsonAdapter(null!, _loggerMock.Object);
+        var act = () => new Api1JsonAdapter(null!, _loggerMock.Object, CreateMockSettings());
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -230,7 +247,18 @@ public class Api1JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
 
         // Act & Assert
-        var act = () => new Api1JsonAdapter(httpClient, null!);
+        var act = () => new Api1JsonAdapter(httpClient, null!, CreateMockSettings());
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WhenSettingsIsNull_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var httpClient = _mockHttp.ToHttpClient();
+
+        // Act & Assert
+        var act = () => new Api1JsonAdapter(httpClient, _loggerMock.Object, null!);
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -239,7 +267,7 @@ public class Api1JsonAdapterTests
     {
         // Arrange
         var httpClient = _mockHttp.ToHttpClient();
-        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api1JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act & Assert
         var act = async () => await adapter.GetExchangeRateAsync(null!);

--- a/tests/ExchangeRateComparator.Tests/Adapters/Api2XmlAdapterTests.cs
+++ b/tests/ExchangeRateComparator.Tests/Adapters/Api2XmlAdapterTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using ExchangeRateComparator.Domain.Entities;
 using ExchangeRateComparator.Infrastructure.Adapters;
+using ExchangeRateComparator.Infrastructure.Configuration;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using RichardSzalay.MockHttp;
 
@@ -17,6 +19,21 @@ public class Api2XmlAdapterTests
     {
         _loggerMock = new Mock<ILogger<Api2XmlAdapter>>();
         _mockHttp = new MockHttpMessageHandler();
+    }
+
+    private static IOptions<ExchangeRateApiSettings> CreateMockSettings(string endpointPath = "/api/exchange")
+    {
+        var settings = new ExchangeRateApiSettings
+        {
+            Api2 = new ApiEndpointSettings
+            {
+                BaseUrl = "http://localhost:5298/",
+                EndpointPath = endpointPath,
+                TimeoutSeconds = 10,
+                Enabled = true
+            }
+        };
+        return Options.Create(settings);
     }
 
     [Fact]
@@ -37,7 +54,7 @@ public class Api2XmlAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api2.example.com/");
 
-        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -63,7 +80,7 @@ public class Api2XmlAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api2.example.com/");
 
-        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -87,7 +104,7 @@ public class Api2XmlAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api2.example.com/");
 
-        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -111,7 +128,7 @@ public class Api2XmlAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api2.example.com/");
 
-        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -139,7 +156,7 @@ public class Api2XmlAdapterTests
         httpClient.BaseAddress = new Uri("https://api2.example.com/");
         httpClient.Timeout = TimeSpan.FromMilliseconds(100);
 
-        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -173,7 +190,7 @@ public class Api2XmlAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api2.example.com/");
 
-        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -189,7 +206,7 @@ public class Api2XmlAdapterTests
     {
         // Arrange
         var httpClient = _mockHttp.ToHttpClient();
-        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act & Assert
         adapter.ProviderName.Should().Be("API2-XML");
@@ -199,7 +216,7 @@ public class Api2XmlAdapterTests
     public void Constructor_WhenHttpClientIsNull_ShouldThrowArgumentNullException()
     {
         // Act & Assert
-        var act = () => new Api2XmlAdapter(null!, _loggerMock.Object);
+        var act = () => new Api2XmlAdapter(null!, _loggerMock.Object, CreateMockSettings());
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -210,7 +227,18 @@ public class Api2XmlAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
 
         // Act & Assert
-        var act = () => new Api2XmlAdapter(httpClient, null!);
+        var act = () => new Api2XmlAdapter(httpClient, null!, CreateMockSettings());
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WhenSettingsIsNull_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var httpClient = _mockHttp.ToHttpClient();
+
+        // Act & Assert
+        var act = () => new Api2XmlAdapter(httpClient, _loggerMock.Object, null!);
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -219,7 +247,7 @@ public class Api2XmlAdapterTests
     {
         // Arrange
         var httpClient = _mockHttp.ToHttpClient();
-        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api2XmlAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act & Assert
         var act = async () => await adapter.GetExchangeRateAsync(null!);

--- a/tests/ExchangeRateComparator.Tests/Adapters/Api3JsonAdapterTests.cs
+++ b/tests/ExchangeRateComparator.Tests/Adapters/Api3JsonAdapterTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using ExchangeRateComparator.Domain.Entities;
 using ExchangeRateComparator.Infrastructure.Adapters;
+using ExchangeRateComparator.Infrastructure.Configuration;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using RichardSzalay.MockHttp;
 
@@ -17,6 +19,21 @@ public class Api3JsonAdapterTests
     {
         _loggerMock = new Mock<ILogger<Api3JsonAdapter>>();
         _mockHttp = new MockHttpMessageHandler();
+    }
+
+    private static IOptions<ExchangeRateApiSettings> CreateMockSettings(string endpointPath = "/api/exchange")
+    {
+        var settings = new ExchangeRateApiSettings
+        {
+            Api3 = new ApiEndpointSettings
+            {
+                BaseUrl = "http://localhost:5298/",
+                EndpointPath = endpointPath,
+                TimeoutSeconds = 10,
+                Enabled = true
+            }
+        };
+        return Options.Create(settings);
     }
 
     [Fact]
@@ -40,7 +57,7 @@ public class Api3JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api3.example.com/");
 
-        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -75,7 +92,7 @@ public class Api3JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api3.example.com/");
 
-        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -99,7 +116,7 @@ public class Api3JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api3.example.com/");
 
-        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -123,7 +140,7 @@ public class Api3JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api3.example.com/");
 
-        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -147,7 +164,7 @@ public class Api3JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api3.example.com/");
 
-        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -175,7 +192,7 @@ public class Api3JsonAdapterTests
         httpClient.BaseAddress = new Uri("https://api3.example.com/");
         httpClient.Timeout = TimeSpan.FromMilliseconds(100);
 
-        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -212,7 +229,7 @@ public class Api3JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
         httpClient.BaseAddress = new Uri("https://api3.example.com/");
 
-        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act
         var result = await adapter.GetExchangeRateAsync(request);
@@ -228,7 +245,7 @@ public class Api3JsonAdapterTests
     {
         // Arrange
         var httpClient = _mockHttp.ToHttpClient();
-        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act & Assert
         adapter.ProviderName.Should().Be("API3-JSON");
@@ -238,7 +255,7 @@ public class Api3JsonAdapterTests
     public void Constructor_WhenHttpClientIsNull_ShouldThrowArgumentNullException()
     {
         // Act & Assert
-        var act = () => new Api3JsonAdapter(null!, _loggerMock.Object);
+        var act = () => new Api3JsonAdapter(null!, _loggerMock.Object, CreateMockSettings());
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -249,7 +266,18 @@ public class Api3JsonAdapterTests
         var httpClient = _mockHttp.ToHttpClient();
 
         // Act & Assert
-        var act = () => new Api3JsonAdapter(httpClient, null!);
+        var act = () => new Api3JsonAdapter(httpClient, null!, CreateMockSettings());
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WhenSettingsIsNull_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var httpClient = _mockHttp.ToHttpClient();
+
+        // Act & Assert
+        var act = () => new Api3JsonAdapter(httpClient, _loggerMock.Object, null!);
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -258,7 +286,7 @@ public class Api3JsonAdapterTests
     {
         // Arrange
         var httpClient = _mockHttp.ToHttpClient();
-        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object);
+        var adapter = new Api3JsonAdapter(httpClient, _loggerMock.Object, CreateMockSettings());
 
         // Act & Assert
         var act = async () => await adapter.GetExchangeRateAsync(null!);

--- a/tests/ExchangeRateComparator.Tests/Services/ExchangeRateComparatorServiceTests.cs
+++ b/tests/ExchangeRateComparator.Tests/Services/ExchangeRateComparatorServiceTests.cs
@@ -226,6 +226,37 @@ public class ExchangeRateComparatorServiceTests
         result.Provider.Should().Be("Provider3");
     }
 
+    [Fact]
+    public async Task GetBestExchangeRateAsync_WhenConvertedAmountsAreEqual_ShouldSelectFastestProvider()
+    {
+        // Arrange
+        var request = new ExchangeRequest("USD", "EUR", 1000M);
+
+        // All providers return same converted amount, but different execution times
+        _provider1Mock
+            .Setup(p => p.GetExchangeRateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ExchangeResult.Success("Provider1", 0.85M, 850M, 150));
+
+        _provider2Mock
+            .Setup(p => p.GetExchangeRateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ExchangeResult.Success("Provider2", 0.85M, 850M, 80));
+
+        _provider3Mock
+            .Setup(p => p.GetExchangeRateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ExchangeResult.Success("Provider3", 0.85M, 850M, 120));
+
+        var providers = new[] { _provider1Mock.Object, _provider2Mock.Object, _provider3Mock.Object };
+        var service = new ExchangeRateComparatorService(providers, _loggerMock.Object);
+
+        // Act
+        var result = await service.GetBestExchangeRateAsync(request);
+
+        // Assert
+        result.ConvertedAmount.Should().Be(850M);
+        result.BestRate.Should().Be(0.85M);
+        result.Provider.Should().Be("Provider2", "it has the fastest execution time (80ms)");
+    }
+
     [Theory]
     [InlineData(null, "EUR", 1000)]
     [InlineData("", "EUR", 1000)]


### PR DESCRIPTION
## Summary
This PR adds support for configurable endpoint paths in API adapters and improves the rate selection algorithm with time-based tiebreaking.

## Changes Made

### Configurable Endpoint Paths (Fixes #1 and #2)
- ✅ Added `EndpointPath` property to `ApiEndpointSettings` with default value `/api/exchange`
- ✅ Updated all three adapters (`Api1JsonAdapter`, `Api2XmlAdapter`, `Api3JsonAdapter`) to inject `IOptions<ExchangeRateApiSettings>`
- ✅ Each adapter now uses the configurable `EndpointPath` instead of hardcoded path
- ✅ Updated `appsettings.json` to demonstrate endpoint path configuration
- ✅ Updated all adapter tests to support `IOptions` pattern
- ✅ Added 3 new tests for settings parameter validation

### Time-Based Selection Enhancement
- ✅ Improved best rate selection to use execution time as tiebreaker
- ✅ When multiple providers return same converted amount, fastest provider is selected
- ✅ Enhanced logging to include execution time in result messages
- ✅ Added test to verify time-based tiebreaker behavior

## Benefits
- 🔧 Each API can now have a unique endpoint path configured in `appsettings.json`
- ⚡ Intelligent provider selection: highest amount first, then fastest execution
- ♻️ Backward compatible - default path `/api/exchange` preserves existing behavior
- 🧪 All 62 tests passing (4 new tests added)
- 📦 Clean Architecture maintained with proper dependency injection

## Selection Logic
```csharp
// Primary: Highest converted amount
// Secondary: Fastest execution time (tiebreaker)
var bestResult = successfulResults
    .OrderByDescending(r => r.ConvertedAmount)
    .ThenBy(r => r.ExecutionTimeMs)
    .First();
```

## Testing
```bash
dotnet build  # Build succeeded
dotnet test   # 62 tests passed, 0 failed
```

Closes #1
Closes #2